### PR TITLE
#13 Edit Action.

### DIFF
--- a/app/src/main/java/tech/thdev/composable/architecture/app/feature/main/MainActivity.kt
+++ b/app/src/main/java/tech/thdev/composable/architecture/app/feature/main/MainActivity.kt
@@ -10,7 +10,6 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -19,7 +18,8 @@ import tech.thdev.composable.architecture.alert.system.CaAlertScreen
 import tech.thdev.composable.architecture.app.feature.main.compose.MainScreen
 import tech.thdev.composable.architecture.app.feature.main.ui.theme.TComposableArchitectureTheme
 import tech.thdev.composable.architecture.base.CaActionActivity
-import tech.thdev.composable.architecture.util.collectAsEvent
+import tech.thdev.composable.architecture.lifecycle.LaunchedLifecycleViewModel
+import tech.thdev.composable.architecture.lifecycle.collectLifecycleEvent
 
 @AndroidEntryPoint
 class MainActivity : CaActionActivity() {
@@ -56,11 +56,11 @@ class MainActivity : CaActionActivity() {
                 )
             }
 
-            LaunchedEffect(Unit) {
-                mainViewModel.loadAction()
-            }
+            LaunchedLifecycleViewModel(
+                viewModel = mainViewModel,
+            )
 
-            mainViewModel.sideEffect.collectAsEvent {
+            mainViewModel.sideEffect.collectLifecycleEvent {
                 when (it) {
                     SideEffect.ShowToast -> {
                         Toast.makeText(this@MainActivity, "message", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/tech/thdev/composable/architecture/app/feature/main/SideEffect.kt
+++ b/app/src/main/java/tech/thdev/composable/architecture/app/feature/main/SideEffect.kt
@@ -1,8 +1,6 @@
 package tech.thdev.composable.architecture.app.feature.main
 
-import tech.thdev.composable.architecture.action.system.CaSideEffect
-
-sealed interface SideEffect : CaSideEffect {
+sealed interface SideEffect {
 
     data object ShowToast : SideEffect
 }

--- a/app/src/test/java/tech/thdev/composable/architecture/app/feature/main/MainViewModelTest.kt
+++ b/app/src/test/java/tech/thdev/composable/architecture/app/feature/main/MainViewModelTest.kt
@@ -6,8 +6,8 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import tech.thdev.composable.architecture.action.system.CaAction
 import tech.thdev.composable.architecture.action.system.FlowCaActionStream
 import tech.thdev.composable.architecture.alert.system.CaAlertAction
 import tech.thdev.composable.architecture.app.R
@@ -30,7 +30,7 @@ internal class MainViewModelTest {
         whenever(flowCaActionStream.flowAction()).thenReturn(flowOf(mockItem))
 
         viewModel.flowAction.test {
-            Assert.assertEquals(CaAction.None, awaitItem())
+            Assert.assertEquals(mockItem, awaitItem())
 
             cancelAndIgnoreRemainingEvents()
         }
@@ -48,7 +48,9 @@ internal class MainViewModelTest {
         whenever(flowCaActionStream.flowAction()).thenReturn(flowOf(mockItem))
 
         viewModel.flowAction.test {
-            Assert.assertEquals(
+            Assert.assertEquals(mockItem, awaitItem())
+
+            verify(flowCaActionStream).nextAction(
                 CaAlertAction.Dialog(
                     icon = R.drawable.baseline_info_24,
                     title = "title",
@@ -61,8 +63,7 @@ internal class MainViewModelTest {
                     onDismissButtonAction = CaAlertAction.Snack(
                         message = "Dismiss",
                     ),
-                ),
-                awaitItem()
+                )
             )
 
             cancelAndIgnoreRemainingEvents()

--- a/core/ui/composable-architecture-alert-system/src/main/java/tech/thdev/composable/architecture/alert/system/CaAlertAction.kt
+++ b/core/ui/composable-architecture-alert-system/src/main/java/tech/thdev/composable/architecture/alert/system/CaAlertAction.kt
@@ -6,14 +6,16 @@ import tech.thdev.composable.architecture.action.system.CaAction
 
 sealed interface CaAlertAction : CaAction {
 
+    data object None : CaAlertAction
+
     data class Dialog(
         val title: String = "",
         val message: String = "",
         val confirmButtonText: String = "",
-        val onConfirmButtonAction: CaAction = CaAction.None,
+        val onConfirmButtonAction: CaAction = None,
         val dismissButtonText: String = "",
-        val onDismissButtonAction: CaAction = CaAction.None,
-        val onDismissRequest: CaAction = CaAction.None,
+        val onDismissButtonAction: CaAction = None,
+        val onDismissRequest: CaAction = None,
         @DrawableRes val icon: Int = View.NO_ID,
         val dismissOnBackPress: Boolean = true,
         val dismissOnClickOutside: Boolean = true,
@@ -22,8 +24,8 @@ sealed interface CaAlertAction : CaAction {
     data class Snack(
         val message: String = "",
         val actionLabel: String = "",
-        val onAction: CaAction = CaAction.None,
-        val onDismiss: CaAction = CaAction.None,
+        val onAction: CaAction = None,
+        val onDismiss: CaAction = None,
         val duration: Duration = if (actionLabel.isNotEmpty()) {
             Duration.Indefinite
         } else {

--- a/core/ui/composable-architecture-alert-system/src/main/java/tech/thdev/composable/architecture/alert/system/CaAlertSystem.kt
+++ b/core/ui/composable-architecture-alert-system/src/main/java/tech/thdev/composable/architecture/alert/system/CaAlertSystem.kt
@@ -2,13 +2,13 @@ package tech.thdev.composable.architecture.alert.system
 
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import tech.thdev.composable.architecture.alert.system.compose.CaDialogScreen
 import tech.thdev.composable.architecture.alert.system.compose.CaSnackScreen
 import tech.thdev.composable.architecture.alert.system.model.CaAlertUiState
+import tech.thdev.composable.architecture.lifecycle.LaunchedLifecycleViewModel
 
 @Composable
 fun CaAlertScreen(
@@ -45,7 +45,7 @@ private fun InternalCaAlertScreen(
         else -> {} // Do nothing
     }
 
-    LaunchedEffect(Unit) {
-        caAlertViewModel.loadAction()
-    }
+    LaunchedLifecycleViewModel(
+        viewModel = caAlertViewModel,
+    )
 }

--- a/core/ui/composable-architecture-alert-system/src/main/java/tech/thdev/composable/architecture/alert/system/CaAlertViewModel.kt
+++ b/core/ui/composable-architecture-alert-system/src/main/java/tech/thdev/composable/architecture/alert/system/CaAlertViewModel.kt
@@ -5,7 +5,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import tech.thdev.composable.architecture.action.system.CaAction
-import tech.thdev.composable.architecture.action.system.CaSideEffect
 import tech.thdev.composable.architecture.action.system.FlowCaActionStream
 import tech.thdev.composable.architecture.alert.system.model.CaAlertUiState
 import tech.thdev.composable.architecture.base.CaViewModel
@@ -13,8 +12,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class CaAlertViewModel @Inject constructor(
-    private val flowCaActionStream: FlowCaActionStream,
-) : CaViewModel<CaAlertAction, CaSideEffect>(
+    flowCaActionStream: FlowCaActionStream,
+) : CaViewModel<CaAlertAction>(
     flowCaActionStream = flowCaActionStream,
     actionClass = CaAlertAction::class,
 ) {
@@ -22,7 +21,7 @@ class CaAlertViewModel @Inject constructor(
     private val _alertUiState = MutableStateFlow<CaAlertUiState?>(null)
     internal val alertUiState = _alertUiState.asStateFlow()
 
-    override suspend fun reducer(action: CaAlertAction): CaAction =
+    override suspend fun reducer(action: CaAlertAction) {
         when (action) {
             is CaAlertAction.Dialog -> {
                 _alertUiState.value = CaAlertUiState.Dialog(
@@ -37,7 +36,6 @@ class CaAlertViewModel @Inject constructor(
                     dismissOnBackPress = action.dismissOnBackPress,
                     dismissOnClickOutside = action.dismissOnClickOutside,
                 )
-                CaAction.None
             }
 
             is CaAlertAction.Snack -> {
@@ -48,9 +46,11 @@ class CaAlertViewModel @Inject constructor(
                     onDismiss = action.onDismiss,
                     duration = action.duration.convert(),
                 )
-                CaAction.None
             }
+
+            is CaAlertAction.None -> {}
         }
+    }
 
     private fun CaAlertAction.Snack.Duration.convert(): SnackbarDuration =
         when (this) {
@@ -60,6 +60,6 @@ class CaAlertViewModel @Inject constructor(
 
     internal fun send(nextEvent: CaAction) {
         _alertUiState.value = null
-        flowCaActionStream.nextAction(nextEvent)
+        nextAction(nextEvent)
     }
 }

--- a/core/ui/composable-architecture-alert-system/src/main/java/tech/thdev/composable/architecture/alert/system/model/CaAlertUiState.kt
+++ b/core/ui/composable-architecture-alert-system/src/main/java/tech/thdev/composable/architecture/alert/system/model/CaAlertUiState.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.SnackbarDuration
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import tech.thdev.composable.architecture.action.system.CaAction
+import tech.thdev.composable.architecture.alert.system.CaAlertAction
 
 @Stable
 internal sealed interface CaAlertUiState {
@@ -30,10 +31,10 @@ internal sealed interface CaAlertUiState {
                 title = "",
                 message = "",
                 confirmButtonText = "",
-                onConfirmButtonAction = CaAction.None,
+                onConfirmButtonAction = CaAlertAction.None,
                 dismissButtonText = "",
-                onDismissButtonAction = CaAction.None,
-                onDismissRequest = CaAction.None,
+                onDismissButtonAction = CaAlertAction.None,
+                onDismissRequest = CaAlertAction.None,
                 icon = View.NO_ID,
                 dismissOnBackPress = true,
                 dismissOnClickOutside = true,
@@ -59,8 +60,8 @@ internal sealed interface CaAlertUiState {
             val Default = Snack(
                 message = "",
                 actionLabel = "",
-                onAction = CaAction.None,
-                onDismiss = CaAction.None,
+                onAction = CaAlertAction.None,
+                onDismiss = CaAlertAction.None,
                 duration = SnackbarDuration.Indefinite,
             )
         }

--- a/core/ui/composable-architecture-alert-system/src/test/java/tech/thdev/composable/architecture/alert/system/DialogViewModelTest.kt
+++ b/core/ui/composable-architecture-alert-system/src/test/java/tech/thdev/composable/architecture/alert/system/DialogViewModelTest.kt
@@ -1,23 +1,16 @@
 package tech.thdev.composable.architecture.alert.system
 
-import android.os.Build
 import app.cash.turbine.test
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
-import tech.thdev.composable.architecture.action.system.CaAction
 import tech.thdev.composable.architecture.action.system.FlowCaActionStream
 import tech.thdev.composable.architecture.alert.system.model.CaAlertUiState
 
-@Config(sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
-@RunWith(RobolectricTestRunner::class)
 internal class DialogViewModelTest {
 
     private val flowCaActionStream = mock<FlowCaActionStream>()
@@ -37,10 +30,10 @@ internal class DialogViewModelTest {
             title = "title",
             message = "message",
             confirmButtonText = "confirmButtonText",
-            onConfirmButtonAction = CaAction.None,
+            onConfirmButtonAction = CaAlertAction.None,
             dismissButtonText = "dismissButtonText",
-            onDismissButtonAction = CaAction.None,
-            onDismissRequest = CaAction.None,
+            onDismissButtonAction = CaAlertAction.None,
+            onDismissRequest = CaAlertAction.None,
         )
         whenever(flowCaActionStream.flowAction()).thenReturn(flowOf(mockItem))
 
@@ -51,10 +44,8 @@ internal class DialogViewModelTest {
                 confirmButtonText = "confirmButtonText",
                 dismissButtonText = "dismissButtonText",
             )
-            Assert.assertEquals(CaAction.None, awaitItem())
+            Assert.assertEquals(mockItem, awaitItem())
             Assert.assertEquals(convert, caAlertViewModel.alertUiState.value)
-
-            verify(flowCaActionStream).nextAction(CaAction.None)
 
             cancelAndIgnoreRemainingEvents()
         }
@@ -65,8 +56,8 @@ internal class DialogViewModelTest {
         val mockItem = CaAlertAction.Snack(
             message = "message",
             actionLabel = "actionLabel",
-            onAction = CaAction.None,
-            onDismiss = CaAction.None,
+            onAction = CaAlertAction.None,
+            onDismiss = CaAlertAction.None,
         )
         whenever(flowCaActionStream.flowAction()).thenReturn(flowOf(mockItem))
 
@@ -75,10 +66,8 @@ internal class DialogViewModelTest {
                 message = "message",
                 actionLabel = "actionLabel",
             )
-            Assert.assertEquals(CaAction.None, awaitItem())
+            Assert.assertEquals(mockItem, awaitItem())
             Assert.assertEquals(convert, caAlertViewModel.alertUiState.value)
-
-            verify(flowCaActionStream).nextAction(CaAction.None)
 
             cancelAndIgnoreRemainingEvents()
         }
@@ -86,8 +75,8 @@ internal class DialogViewModelTest {
 
     @Test
     fun `test send`() {
-        caAlertViewModel.send(CaAction.None)
+        caAlertViewModel.send(CaAlertAction.None)
         Assert.assertNull(caAlertViewModel.alertUiState.value)
-        verify(flowCaActionStream).nextAction(CaAction.None)
+        verify(flowCaActionStream).nextAction(CaAlertAction.None)
     }
 }

--- a/core/ui/composable-architecture-system/src/main/java/tech/thdev/composable/architecture/action/system/CaAction.kt
+++ b/core/ui/composable-architecture-system/src/main/java/tech/thdev/composable/architecture/action/system/CaAction.kt
@@ -12,7 +12,4 @@ package tech.thdev.composable.architecture.action.system
  * }
  * ```
  */
-interface CaAction {
-
-    data object None : CaAction
-}
+interface CaAction

--- a/core/ui/composable-architecture-system/src/main/java/tech/thdev/composable/architecture/action/system/CaSideEffect.kt
+++ b/core/ui/composable-architecture-system/src/main/java/tech/thdev/composable/architecture/action/system/CaSideEffect.kt
@@ -1,3 +1,0 @@
-package tech.thdev.composable.architecture.action.system
-
-interface CaSideEffect

--- a/core/ui/composable-architecture-system/src/main/java/tech/thdev/composable/architecture/action/system/FlowCaActionStream.kt
+++ b/core/ui/composable-architecture-system/src/main/java/tech/thdev/composable/architecture/action/system/FlowCaActionStream.kt
@@ -3,13 +3,15 @@ package tech.thdev.composable.architecture.action.system
 import kotlinx.coroutines.flow.Flow
 
 /**
- * Definitions for utilizing [CaAction] events in a [ViewModel].
+ * Definitions for utilizing [CaAction] events in a [tech.thdev.composable.architecture.base.CaViewModel].
  *
  * ```kotlin
- * @HiltViewModel
- * class MainViewModel @Inject constructor(
+ * class MainViewModel constructor(
  *     flowCaActionStream: FlowCaActionStream,
  * ) : ViewModel() {
+ *
+ *      private val _sideEffect = Channel<InternalSideEffect>(Channel.BUFFERED)
+ *      internal val sideEffect = _sideEffect.receiveAsFlow()
  *
  *     // Handle events received through CaActionSender
  *     @VisibleForTesting
@@ -26,17 +28,10 @@ import kotlinx.coroutines.flow.Flow
  *     }
  *
  *     // Definition for using CA Action as a reducer
- *     private fun reducer(action: CaAction): Flow<CaAction> {
+ *     private fun reducer(action: CaAction) {
  *         return when (action) {
  *             is DefaultAction.AppEnd -> {
- *                 flowOf(CaActionNone)
- *                     .onEach {
- *                         _sideEffect.tryEmit(SideEffect.End)
- *                     }
- *             }
- *
- *             else -> {
- *                 flowOf(CaActionNone)
+ *                  _sideEffect.send(SideEffect.End)
  *             }
  *         }
  *     }

--- a/core/ui/composable-architecture-system/src/main/java/tech/thdev/composable/architecture/action/system/compose/LocalCaActionSenderOwner.kt
+++ b/core/ui/composable-architecture-system/src/main/java/tech/thdev/composable/architecture/action/system/compose/LocalCaActionSenderOwner.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import tech.thdev.composable.architecture.action.system.CaActionSender
 
 /**
- * Define [CaActionSend] at the beginning of the Compose hierarchy.
+ * Define [tech.thdev.composable.architecture.action.system.CaActionSender] at the beginning of the Compose hierarchy.
  * Since Hilt Singleton is used, it's injected as follows:
  *
  * Apply action

--- a/core/ui/composable-architecture-system/src/main/java/tech/thdev/composable/architecture/action/system/internal/InternalCaAction.kt
+++ b/core/ui/composable-architecture-system/src/main/java/tech/thdev/composable/architecture/action/system/internal/InternalCaAction.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.filter
 import tech.thdev.composable.architecture.action.system.CaAction
 import tech.thdev.composable.architecture.action.system.CaActionSender
 import tech.thdev.composable.architecture.action.system.FlowCaActionStream
@@ -21,7 +20,6 @@ class InternalCaAction @Inject constructor() : FlowCaActionStream, CaActionSende
 
     override fun flowAction(): Flow<CaAction> =
         flowCaAction.asSharedFlow()
-            .filter { it != CaAction.None }
 
     override fun send(action: CaAction) {
         flowCaAction.tryEmit(action)

--- a/core/ui/composable-architecture-system/src/main/java/tech/thdev/composable/architecture/lifecycle/CollectLifecycleEvent.kt
+++ b/core/ui/composable-architecture-system/src/main/java/tech/thdev/composable/architecture/lifecycle/CollectLifecycleEvent.kt
@@ -1,4 +1,4 @@
-package tech.thdev.composable.architecture.util
+package tech.thdev.composable.architecture.lifecycle
 
 import android.annotation.SuppressLint
 import androidx.compose.runtime.Composable
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.collectLatest
 
 @SuppressLint("ComposableNaming")
 @Composable
-fun <T> Flow<T>.collectAsEvent(
+fun <T> Flow<T>.collectLifecycleEvent(
     state: Lifecycle.State = Lifecycle.State.STARTED,
     onBody: (item: T) -> Unit,
 ) {

--- a/core/ui/composable-architecture-system/src/main/java/tech/thdev/composable/architecture/lifecycle/LaunchedLifecycleViewModel.kt
+++ b/core/ui/composable-architecture-system/src/main/java/tech/thdev/composable/architecture/lifecycle/LaunchedLifecycleViewModel.kt
@@ -1,0 +1,52 @@
+package tech.thdev.composable.architecture.lifecycle
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import tech.thdev.composable.architecture.base.CaViewModel
+
+/**
+ * This code must be used in conjunction with CaViewModel<*>.
+ * It can be used as shown below.
+ *
+ * ```kotlin
+ * class MainActivity : CaActionActivity() {
+ *
+ *      private val mainViewModel by viewModels<MainViewModel>()
+ *
+ *      @Composable
+ *      override fun ContentView() {
+ *      TComposableArchitectureTheme {
+ *          LaunchedLifecycleViewModel(viewModel = mainViewModel) // Required
+ *
+ *          // Your Compose view
+ *      }
+ *  }
+ * }
+ * ```
+ */
+@Composable
+fun LaunchedLifecycleViewModel(viewModel: CaViewModel<*>) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_RESUME -> {
+                    viewModel.loadAction()
+                }
+
+                Lifecycle.Event.ON_PAUSE -> {
+                    viewModel.cancelAction()
+                }
+
+                else -> {}
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+}

--- a/core/ui/composable-architecture-system/src/test/java/tech/thdev/composable/architecture/action/system/internal/InternalCaActionTest.kt
+++ b/core/ui/composable-architecture-system/src/test/java/tech/thdev/composable/architecture/action/system/internal/InternalCaActionTest.kt
@@ -1,18 +1,12 @@
 package tech.thdev.composable.architecture.action.system.internal
 
-import android.os.Build
 import app.cash.turbine.test
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import tech.thdev.composable.architecture.action.system.CaAction
 
-@Config(sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
-@RunWith(RobolectricTestRunner::class)
-class InternalCaActionSenderTest {
+class InternalCaActionTest {
 
     private val flowAction = InternalCaAction()
 
@@ -20,10 +14,6 @@ class InternalCaActionSenderTest {
     fun `test flowAction`() = runTest {
         flowAction.flowAction()
             .test {
-                expectNoEvents()
-
-                // If the action is none, do not process it.
-                flowAction.send(CaAction.None)
                 expectNoEvents()
 
                 flowAction.send(SomeAction)

--- a/core/ui/composable-architecture-system/src/test/java/tech/thdev/composable/architecture/base/CaViewModelTest.kt
+++ b/core/ui/composable-architecture-system/src/test/java/tech/thdev/composable/architecture/base/CaViewModelTest.kt
@@ -1,0 +1,44 @@
+package tech.thdev.composable.architecture.base
+
+import app.cash.turbine.test
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Test
+import tech.thdev.composable.architecture.base.mock.MockAction
+import tech.thdev.composable.architecture.base.mock.MockViewModel
+
+class CaViewModelTest {
+
+    private val viewModel = MockViewModel()
+
+    @Test
+    fun `test initData`() {
+        Assert.assertFalse(viewModel.taskClick)
+        Assert.assertFalse(viewModel.clickEvent)
+        Assert.assertNull(viewModel.flowActionJob)
+    }
+
+    @Test
+    fun `test Action-Task`() = runTest {
+        viewModel.flowAction.test {
+            expectNoEvents()
+
+            viewModel.nextAction(MockAction.Task)
+            Assert.assertTrue(viewModel.taskClick)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `test Action-ClickEvent`() = runTest {
+        viewModel.flowAction.test {
+            expectNoEvents()
+
+            viewModel.nextAction(MockAction.ClickEvent)
+            Assert.assertTrue(viewModel.clickEvent)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/core/ui/composable-architecture-system/src/test/java/tech/thdev/composable/architecture/base/mock/MockAction.kt
+++ b/core/ui/composable-architecture-system/src/test/java/tech/thdev/composable/architecture/base/mock/MockAction.kt
@@ -1,0 +1,10 @@
+package tech.thdev.composable.architecture.base.mock
+
+import tech.thdev.composable.architecture.action.system.CaAction
+
+sealed interface MockAction : CaAction {
+
+    data object Task : MockAction
+
+    data object ClickEvent : MockAction
+}

--- a/core/ui/composable-architecture-system/src/test/java/tech/thdev/composable/architecture/base/mock/MockViewModel.kt
+++ b/core/ui/composable-architecture-system/src/test/java/tech/thdev/composable/architecture/base/mock/MockViewModel.kt
@@ -1,0 +1,27 @@
+package tech.thdev.composable.architecture.base.mock
+
+import tech.thdev.composable.architecture.action.system.internal.InternalCaAction
+import tech.thdev.composable.architecture.base.CaViewModel
+
+internal class MockViewModel : CaViewModel<MockAction>(
+    flowCaActionStream = InternalCaAction(),
+    actionClass = MockAction::class,
+) {
+
+    var taskClick = false
+
+    var clickEvent = false
+
+    override suspend fun reducer(action: MockAction) {
+        println(action)
+        when (action) {
+            MockAction.Task -> {
+                taskClick = true
+            }
+
+            MockAction.ClickEvent -> {
+                clickEvent = true
+            }
+        }
+    }
+}


### PR DESCRIPTION
Usage change:
Instead of forcing nextAction, modify to directly call nextAction() for usage to prevent infinite loops.
- remove flow nextAction()
Added LaunchedLifecycleViewModel to modify the design to follow Lifecycle onResume/onPause events.

```kotlin
@AndroidEntryPoint
class MainActivity : CaActionActivity() {

    private val mainViewModel by viewModels<MainViewModel>()

    @Composable
    override fun ContentView() {
        TComposableArchitectureTheme {
            LaunchedLifecycleViewModel( // use lifecycle viewModel
                viewModel = mainViewModel,
            )
        }
    }
}
```
- Remove the direct implementation and usage of SideEffect in BaseViewModel.